### PR TITLE
chore: update devcontainer.json to use goreleaser feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
   "features": {
-    // "ghcr.io/devcontainers-contrib/features/peco-asdf:2": {}
+    "ghcr.io/guiyomh/features/goreleaser:0": {}
   }
 
   // Features to add to the dev container. More info: https://containers.dev/features.


### PR DESCRIPTION
Releases are done in goreleaser so that they can be taken right out of the box when the development container is launched.